### PR TITLE
Flagception\Manager\FeatureManagerInterface service fix

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,6 +5,8 @@ services:
             - '@flagception.activator.chain_activator'
             - '@flagception.decorator.chain_decorator'
         public: true
+        
+    Flagception\Manager\FeatureManagerInterface: '@flagception.manager.feature_manager'
 
     flagception.expression_language:
         class: Symfony\Component\ExpressionLanguage\ExpressionLanguage


### PR DESCRIPTION
This fixes the following deprecation issue, maintaining backward compatibility:

Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "flagception.manager.feature_manager" service to "Flagception\Manager\FeatureManagerInterface" instead.