### PR TITLE
fix: fixed susbcriber for invokable controllers

### DIFF
--- a/src/Listener/AnnotationSubscriber.php
+++ b/src/Listener/AnnotationSubscriber.php
@@ -58,7 +58,11 @@ class AnnotationSubscriber implements EventSubscriberInterface
      */
     public function onKernelController(ControllerEvent $event)
     {
-        $controller = $event->getController();
+        $eventController = $event->getController();
+
+        $controller =  is_array($eventController) === false && method_exists($eventController, '__invoke')
+            ? [$eventController, '__invoke']
+            : $eventController;
 
         /*
          * $controller passed can be either a class or a Closure.


### PR DESCRIPTION
fixed for invokable controller and shorten routing definition: 
[symfony-invokable controllers](
https://symfony.com/doc/current/controller/service.html#invokable-controllers)

**dont work before this MR:**
customer_promotional_voucher_list:
  path: /promotional-vouchers
  controller: App\Controller\Customer\Voucher\PromotionalVoucherListControlle

**work only**
  path: /promotional-vouchers
  controller: App\Controller\Customer\Voucher\PromotionalVoucherListController::**__invoke**
