### PR TITLE
fixed susbcriber for invokable controllers

### DIFF
--- a/src/Listener/AnnotationSubscriber.php
+++ b/src/Listener/AnnotationSubscriber.php
@@ -58,7 +58,10 @@ class AnnotationSubscriber implements EventSubscriberInterface
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        $controller = $event->getController();
+        $eventController = $event->getController();
+        $controller =  is_array($eventController) === false && method_exists($eventController, '__invoke')
+            ? [$eventController, '__invoke']
+            : $eventController;
 
         /*
          * $controller passed can be either a class or a Closure.

--- a/src/Listener/AnnotationSubscriber.php
+++ b/src/Listener/AnnotationSubscriber.php
@@ -59,6 +59,7 @@ class AnnotationSubscriber implements EventSubscriberInterface
     public function onKernelController(FilterControllerEvent $event)
     {
         $eventController = $event->getController();
+
         $controller =  is_array($eventController) === false && method_exists($eventController, '__invoke')
             ? [$eventController, '__invoke']
             : $eventController;


### PR DESCRIPTION
fixed for invokable controller and shorten routing definition:
symfony-invokable controllers

dont work before this MR:
customer_promotional_voucher_list:
path: /promotional-vouchers
controller: App\Controller\Customer\Voucher\PromotionalVoucherListControlle

work only
path: /promotional-vouchers
controller: App\Controller\Customer\Voucher\PromotionalVoucherListController::__invoke