### PR TITLE
Enabled support for twig v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "symfony/yaml": "^5.0",
     "symfony/config": "^5.0",
     "symfony/http-kernel": "^5.0",
-    "twig/twig": "^1.18|^2.0",
+    "twig/twig": "^1.18|^2.0|^3.0",
     "doctrine/annotations": "^1.0",
     "flagception/flagception": "^1.5"
   },


### PR DESCRIPTION
Hey. I enabled the use of twig v3 again. I am not sure why it was dropped.