### PR TITLE
Allow checking for multiple features in route definition

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -85,7 +85,88 @@ or via xml
         <controller>AppBundle:Blog:list</controller>
         <default key="_feature">feature_123</default>
     </route>
-    
+
+    <!-- ... -->
+</routes>
+```
+
+To check for multiple features, pass them as an array to the route definition.
+
+```php
+// src/AppBundle/Controller/BlogController.php
+// src/Controller/BlogController.php
+namespace AppBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+class BlogController extends Controller
+{
+    /**
+     * @Route("/blog/{page}", defaults={"_feature": {"feature_123", "feature_456"}})
+     */
+    public function listAction($page)
+    {
+        // ...
+    }
+
+    /**
+     * @Route("/blog/{slug}")
+     */
+    public function showAction($slug)
+    {
+        // ...
+    }
+}
+```
+or via yml
+
+```yml
+# app/config/routing.yml
+blog_list:
+    path:      /blog/{page}
+    defaults:  { _controller: AppBundle:Blog:list, _feature: ['feature_456', 'feature_789'] }
+
+# Symfony 3.4 / 4.0
+blog_list:
+    path:       /blog/{page}
+    controller: AppBundle:Blog:list
+    defaults:   { _feature: ['feature_456', 'feature_789'] }
+
+blog_show:
+```
+
+or via xml
+
+```xml
+<!-- app/config/routing.xml -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="blog_list" path="/blog/{page}">
+        <default key="_controller">AppBundle:Blog:list</default>
+        <default key="_feature">
+            <list>
+                <string>feature_123</string>
+                <string>feature_456</string>
+            </list>
+        </default>
+    </route>
+
+    <!-- Symfony 3.4 / 4.0 -->
+    <route id="blog_list" path="/blog/{page}">
+        <controller>AppBundle:Blog:list</controller>
+        <default key="_feature">
+            <list>
+                <string>feature_123</string>
+                <string>feature_456</string>
+            </list>
+        </default>
+    </route>
+
     <!-- ... -->
 </routes>
 ```

--- a/src/Listener/RoutingMetadataSubscriber.php
+++ b/src/Listener/RoutingMetadataSubscriber.php
@@ -54,9 +54,11 @@ class RoutingMetadataSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $featureName = $event->getRequest()->attributes->get(static::FEATURE_KEY);
-        if (!$this->manager->isActive($featureName)) {
-            throw new NotFoundHttpException('Feature for this class is not active.');
+        $featureNames = (array) $event->getRequest()->attributes->get(static::FEATURE_KEY);
+        foreach ($featureNames as $featureName) {
+            if (!$this->manager->isActive($featureName)) {
+                throw new NotFoundHttpException('Feature for this class is not active.');
+            }
         }
     }
 

--- a/tests/Listener/RoutingMetadataSubscriberTest.php
+++ b/tests/Listener/RoutingMetadataSubscriberTest.php
@@ -117,4 +117,56 @@ class RoutingMetadataSubscriberTest extends TestCase
         $subscriber = new RoutingMetadataSubscriber($manager);
         $subscriber->onKernelController($event);
     }
+
+    /**
+     * Test features are not active
+     *
+     * @return void
+     */
+    public function testRouteWithMultipleFeaturesIsNotActive()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $request = new Request([], [], ['_feature' => ['feature_abc', 'feature_def']]);
+
+        $event = $this->createMock(FilterControllerEvent::class);
+        $event
+            ->method('getRequest')
+            ->willReturn($request);
+
+        $manager = $this->createMock(FeatureManagerInterface::class);
+        $manager
+            ->expects(static::exactly(2))
+            ->method('isActive')
+            ->withConsecutive(['feature_abc'], ['feature_def'])
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $subscriber = new RoutingMetadataSubscriber($manager);
+        $subscriber->onKernelController($event);
+    }
+
+    /**
+     * Test features are active
+     *
+     * @return void
+     */
+    public function testRouteWithMultipleFeaturesIsActive()
+    {
+        $request = new Request([], [], ['_feature' => ['feature_abc', 'feature_def']]);
+
+        $event = $this->createMock(FilterControllerEvent::class);
+        $event
+            ->method('getRequest')
+            ->willReturn($request);
+
+        $manager = $this->createMock(FeatureManagerInterface::class);
+        $manager
+            ->expects(static::exactly(2))
+            ->method('isActive')
+            ->withConsecutive(['feature_abc'], ['feature_def'])
+            ->willReturnOnConsecutiveCalls(true, true);
+
+        $subscriber = new RoutingMetadataSubscriber($manager);
+        $subscriber->onKernelController($event);
+    }
 }


### PR DESCRIPTION
Actually, you can check for multiple features using PHP expressions, twig expressions or with multiple annotations in the method controller, but with the route definition this is not allowed.

This small PR allows to check for multiple features in route definition.