### PR TITLE
Restore support for Symfony 4.4 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,29 @@
 language: php
-sudo: false
 
-php:
-  - 7.2
-  - 7.3
-
-matrix:
+jobs:
   fast_finish: true
   include:
+    - php: 7.1
+      env: SYMFONY_VERSION='4.4.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: SYMFONY_VERSION='4.4.*'
     - php: 7.2
       env: SYMFONY_VERSION='5.0.*'
+    - php: 7.2
+    - php: 7.3
+      env: SYMFONY_VERSION='4.4.*'
     - php: 7.3
       env: SYMFONY_VERSION='5.0.*'
+    - php: 7.3
+    - php: 7.4
+      env: SYMFONY_VERSION='4.4.*'
+    - php: 7.4
+      env: SYMFONY_VERSION='5.0.*'
+    - php: 7.4
+    - php: nightly
+
+  allow_failures:
+    - php: nightly
 
 before_install:
   - composer self-update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Changed
+- \#82 Restore support for Symfony 4.4 LTS @ajgarlag
+
 ## [4.0.0]
 ### Changed
 - \#67 Add compatibility for Symfony 5 @migo315

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This bundle integrates the [Flagception PHP Libary](https://packagist.org/packag
 | Bundle Version (Tag) | Support Symfony | Branch |
 |----------------------|-----------------|--------|
 | <=3                  | 2.7 - 4.4       | 3.x    |
-| >=4                  | 5.0 - current   | master |
+| >=4                  | 4.4 - current   | master |
 
 ```console
 $ composer require flagception/flagception-bundle

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,5 +1,5 @@
 # Upgrade from 3.x to 4.0
-Version 4 only removes compatibility for Symfony 2, Symfony 3 and Symfony 4. No interfaces or services changed.
+Version 4 only removes compatibility for Symfony 2, Symfony 3 and Symfony <= 4.3. No interfaces or services changed.
 Please notice that the support for [Contentful Activator](https://packagist.org/packages/flagception/contentful-activator) was dropped.
 
 Have fun with Symfony 5 :-)

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,20 @@
     }
   ],
   "require": {
-    "php": "^7.2.5",
-    "symfony/dependency-injection": "^5.0",
-    "symfony/yaml": "^5.0",
-    "symfony/config": "^5.0",
-    "symfony/http-kernel": "^5.0",
+    "php": "^7.1.3 | ^8",
+    "symfony/dependency-injection": "^4.4 | ^5.0",
+    "symfony/yaml": "^4.4 | ^5.0",
+    "symfony/config": "^4.4 | ^5.0",
+    "symfony/http-kernel": "^4.4 | ^5.0",
     "twig/twig": "^1.18|^2.0|^3.0",
-    "doctrine/annotations": "^1.0",
+    "doctrine/annotations": "^1.7",
     "flagception/flagception": "^1.5"
   },
   "require-dev": {
     "symfony/phpunit-bridge": "^5.0",
-    "symfony/twig-bridge": "^5.0",
+    "symfony/twig-bridge": "^4.4 | ^5.0",
     "flagception/database-activator": "^1.0",
-    "phpunit/phpunit": "8.3.*",
-    "php-mock/php-mock-phpunit": "^2.2",
-    "squizlabs/php_codesniffer": "^3.0",
+    "squizlabs/php_codesniffer": "^3.3.1",
     "php-coveralls/php-coveralls": "^2.0"
   },
   "autoload": {
@@ -52,7 +50,7 @@
   "scripts": {
     "tests": [
       "./vendor/bin/phpcs",
-      "./vendor/bin/phpunit --coverage-text"
+      "./vendor/bin/simple-phpunit --coverage-text"
     ]
   }
 }

--- a/tests/DependencyInjection/Configurator/DatabaseConfiguratorTest.php
+++ b/tests/DependencyInjection/Configurator/DatabaseConfiguratorTest.php
@@ -5,7 +5,6 @@ namespace Flagception\Tests\FlagceptionBundle\DependencyInjection\Configurator;
 use Flagception\Bundle\FlagceptionBundle\DependencyInjection\Configurator\DatabaseConfigurator;
 use Flagception\Bundle\FlagceptionBundle\DependencyInjection\FlagceptionExtension;
 use LogicException;
-use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,8 +19,6 @@ use Symfony\Component\DependencyInjection\Loader;
  */
 class DatabaseConfiguratorTest extends TestCase
 {
-    use PHPMock;
-
     /**
      * The container
      *


### PR DESCRIPTION
This PR restores support for Symfony 4.4 LTS in `master` branch.

Fix #81