### PR TITLE
[RFC] ContextResolveEvent to allow context customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - \#80 Support for multiple features in route definition @ajgarlag
+- \#84 ContextResolveEvent to allow context customization when checking for a feature @ajgarlag
 
 ### Changed
 - \#82 Restore support for Symfony 4.4 LTS @ajgarlag

--- a/src/Event/ContextResolveEvent.php
+++ b/src/Event/ContextResolveEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Flagception\Bundle\FlagceptionBundle\Event;
+
+use Flagception\Model\Context;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Class ContextResolveEvent
+ *
+ * @author Antonio J. García Lagar <aj@garcialagar.es>
+ * @package Flagception\Bundle\FlagceptionBundle\Listener
+ */
+class ContextResolveEvent extends Event
+{
+    /**
+     * The context
+     *
+     * @var Context
+     */
+    private $context;
+
+    public function __construct(Context $context = null)
+    {
+        $this->context = $context ?? new Context();
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function setContext(Context $context): void
+    {
+        $this->context = $context;
+    }
+}

--- a/src/Event/ContextResolveEvent.php
+++ b/src/Event/ContextResolveEvent.php
@@ -14,15 +14,28 @@ use Symfony\Contracts\EventDispatcher\Event;
 class ContextResolveEvent extends Event
 {
     /**
+     * The feature
+     *
+     * @var string
+     */
+    private $feature;
+
+    /**
      * The context
      *
      * @var Context
      */
     private $context;
 
-    public function __construct(Context $context = null)
+    public function __construct(string $feature, Context $context = null)
     {
+        $this->feature = $feature;
         $this->context = $context ?? new Context();
+    }
+
+    public function getFeature(): string
+    {
+        return $this->feature;
     }
 
     public function getContext(): Context

--- a/src/Listener/AnnotationSubscriber.php
+++ b/src/Listener/AnnotationSubscriber.php
@@ -87,15 +87,17 @@ class AnnotationSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $context = null;
-        if (null !== $this->eventDispatcher) {
-            $contextEvent = $this->eventDispatcher->dispatch(new ContextResolveEvent());
-            $context = $contextEvent->getContext();
-        }
+
 
         $object = new ReflectionClass($controller[0]);
         foreach ($this->reader->getClassAnnotations($object) as $annotation) {
             if ($annotation instanceof Feature) {
+                $context = null;
+                if (null !== $this->eventDispatcher) {
+                    $contextEvent = $this->eventDispatcher->dispatch(new ContextResolveEvent($annotation->name));
+                    $context = $contextEvent->getContext();
+                }
+
                 if (!$this->manager->isActive($annotation->name, $context)) {
                     throw new NotFoundHttpException('Feature for this class is not active.');
                 }
@@ -104,6 +106,11 @@ class AnnotationSubscriber implements EventSubscriberInterface
 
         $method = $object->getMethod($controller[1]);
         foreach ($this->reader->getMethodAnnotations($method) as $annotation) {
+            $context = null;
+            if (null !== $this->eventDispatcher) {
+                $contextEvent = $this->eventDispatcher->dispatch(new ContextResolveEvent($annotation->name));
+                $context = $contextEvent->getContext();
+            }
             if ($annotation instanceof Feature) {
                 if (!$this->manager->isActive($annotation->name, $context)) {
                     throw new NotFoundHttpException('Feature for this method is not active.');

--- a/src/Listener/RoutingMetadataSubscriber.php
+++ b/src/Listener/RoutingMetadataSubscriber.php
@@ -65,14 +65,13 @@ class RoutingMetadataSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $context = null;
-        if (null !== $this->eventDispatcher) {
-            $contextEvent = $this->eventDispatcher->dispatch(new ContextResolveEvent());
-            $context = $contextEvent->getContext();
-        }
-
         $featureNames = (array) $event->getRequest()->attributes->get(static::FEATURE_KEY);
         foreach ($featureNames as $featureName) {
+            $context = null;
+            if (null !== $this->eventDispatcher) {
+                $contextEvent = $this->eventDispatcher->dispatch(new ContextResolveEvent($featureName));
+                $context = $contextEvent->getContext();
+            }
             if (!$this->manager->isActive($featureName, $context)) {
                 throw new NotFoundHttpException('Feature for this class is not active.');
             }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -17,6 +17,7 @@ services:
         class: Flagception\Bundle\FlagceptionBundle\Twig\ToggleExtension
         arguments:
             - '@flagception.manager.feature_manager'
+            - '@event_dispatcher'
         tags:
             - { name: twig.extension }
         public: false
@@ -69,6 +70,7 @@ services:
         arguments:
             - '@annotations.reader'
             - '@flagception.manager.feature_manager'
+            - '@event_dispatcher'
         tags:
             - { name: kernel.event_subscriber }
         public: true
@@ -78,6 +80,7 @@ services:
         class: Flagception\Bundle\FlagceptionBundle\Listener\RoutingMetadataSubscriber
         arguments:
             - '@flagception.manager.feature_manager'
+            - '@event_dispatcher'
         tags:
             - { name: kernel.event_subscriber }
         public: true

--- a/src/Twig/ToggleExtension.php
+++ b/src/Twig/ToggleExtension.php
@@ -60,7 +60,7 @@ class ToggleExtension extends AbstractExtension
         }
 
         if (null !== $this->eventDispatcher) {
-            $contextEvent = $this->eventDispatcher->dispatch(new ContextResolveEvent($context));
+            $contextEvent = $this->eventDispatcher->dispatch(new ContextResolveEvent($name, $context));
             $context = $contextEvent->getContext();
         }
 

--- a/tests/Listener/AnnotationSubscriberTest.php
+++ b/tests/Listener/AnnotationSubscriberTest.php
@@ -168,6 +168,7 @@ class AnnotationSubscriberTest extends TestCase
         $manager->method('isActive')->with('feature_abc', $context)->willReturn(true);
 
         $listener = function (ContextResolveEvent $event) use ($context) {
+            $this->assertSame('feature_abc', $event->getFeature());
             $this->assertNotSame($event->getContext(), $context);
             $event->setContext($context);
             $this->assertSame($event->getContext(), $context);

--- a/tests/Listener/RoutingMetadataSubscriberTest.php
+++ b/tests/Listener/RoutingMetadataSubscriberTest.php
@@ -208,6 +208,7 @@ class RoutingMetadataSubscriberTest extends TestCase
             ->willReturn(true);
 
         $listener = function (ContextResolveEvent $event) use ($context) {
+            $this->assertSame('feature_abc', $event->getFeature());
             $this->assertNotSame($event->getContext(), $context);
             $event->setContext($context);
             $this->assertSame($event->getContext(), $context);

--- a/tests/Twig/ToggleExtensionTest.php
+++ b/tests/Twig/ToggleExtensionTest.php
@@ -88,6 +88,7 @@ class ToggleExtensionTest extends TestCase
         $context = new Context();
 
         $listener = function (ContextResolveEvent $event) use ($context) {
+            $this->assertSame('feature_foo', $event->getFeature());
             $this->assertNotSame($event->getContext(), $context);
             $event->setContext($context);
             $this->assertSame($event->getContext(), $context);


### PR DESCRIPTION
With this feature, a user can write a listener to allow context customization when checking for a feature.

The dependency on the event dispatcher instance is optional, so it is backward compatible. Maybe it could be required in the next major version.

WDYT?