### PR TITLE
Updating flagception to latest so we can use this together with Sf5.3 and PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "symfony/http-kernel": "^4.4 | ^5.0",
     "twig/twig": "^1.18|^2.0|^3.0",
     "doctrine/annotations": "^1.7",
-    "flagception/flagception": "^1.5"
+    "flagception/flagception": "*"
   },
   "require-dev": {
     "symfony/phpunit-bridge": "^5.0",


### PR DESCRIPTION
Blocked by merge and release of https://github.com/bestit/flagception-sdk/pull/28 so we can remove the * from line 21
