### PR TITLE
support php8 attributes, fixes #97

### DIFF
--- a/src/Annotations/Feature.php
+++ b/src/Annotations/Feature.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Flagception\Bundle\FlagceptionBundle\Annotations;
-
+use \Attribute;
 /**
  * Class Feature
  *
@@ -9,6 +9,8 @@ namespace Flagception\Bundle\FlagceptionBundle\Annotations;
  * @package Flagception\Bundle\FlagceptionBundle\Annotations
  * @Annotation
  */
+
+#[Attribute(Attribute::TARGET_ALL)]
 class Feature
 {
     /**
@@ -17,4 +19,17 @@ class Feature
      * @var string
      */
     public $name;
+
+    public function __construct($name) {
+        if (is_string($name)) {
+            $this->name = $name;
+        } else {
+            $this->name = $name['value'];
+        }
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
 }

--- a/src/Listener/AnnotationSubscriber.php
+++ b/src/Listener/AnnotationSubscriber.php
@@ -74,6 +74,18 @@ class AnnotationSubscriber implements EventSubscriberInterface
         }
 
         $object = new ReflectionClass($controller[0]);
+
+        // check for php8 attributes on the controller class
+        if (method_exists($object, 'getAttributes')) {
+            foreach ($object->getAttributes(Feature::class) as $attribute) {
+                $name = $attribute->getArguments()['name'];
+                if (!$this->manager->isActive($name)) {
+                    throw new NotFoundHttpException(sprintf('Feature %s for class %s is not active.', $name, $object->getName()));
+                }
+            }
+        }
+
+
         foreach ($this->reader->getClassAnnotations($object) as $annotation) {
             if ($annotation instanceof Feature) {
                 if (!$this->manager->isActive($annotation->name)) {
@@ -83,6 +95,17 @@ class AnnotationSubscriber implements EventSubscriberInterface
         }
 
         $method = $object->getMethod($controller[1]);
+
+        // check for php8 attributes on the method
+        if (method_exists($method, 'getAttributes')) {
+            foreach ($method->getAttributes(Feature::class) as $attribute) {
+                $name = $attribute->getArguments()['name'];
+                if (!$this->manager->isActive($name)) {
+                    throw new NotFoundHttpException(sprintf('Feature %s for method %s is not active.', $name, $method->getName()));
+                }
+            }
+        }
+
         foreach ($this->reader->getMethodAnnotations($method) as $annotation) {
             if ($annotation instanceof Feature) {
                 if (!$this->manager->isActive($annotation->name)) {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,11 +1,13 @@
 services:
     flagception.manager.feature_manager:
         class: Flagception\Manager\FeatureManager
+        tags:
+            - { name: routing.condition_service }
         arguments:
             - '@flagception.activator.chain_activator'
             - '@flagception.decorator.chain_decorator'
         public: true
-        
+
     Flagception\Manager\FeatureManagerInterface: '@flagception.manager.feature_manager'
 
     flagception.expression_language:


### PR DESCRIPTION
```php
    #[Feature(name: "abc")]
    #[Route('/demo', name: 'app_demo')]
    public function demo(): Response
    {
        return $this->render('app/index.html.twig', [
            'controller_name' => 'Demo',
        ]);
    }
```

works now, as does using this at the controller class level.