### PR TITLE
tag the service so it can be used in the route condition, #99

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -48,6 +48,18 @@ class BlogController extends Controller
     }
 }
 ```
+
+Symfony 6.1+ can check for the feature in the condition
+```php
+    /**
+     * @Route("/blog/{page}", condition="service('flagception.manager.feature_manager').isActive('feature_123')")
+     */
+    public function listAction($page)
+    {
+        // ...
+    }
+```
+
 or via yml
 
 ```yml

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,11 +1,13 @@
 services:
     flagception.manager.feature_manager:
         class: Flagception\Manager\FeatureManager
+        tags:
+            - { name: routing.condition_service }
         arguments:
             - '@flagception.activator.chain_activator'
             - '@flagception.decorator.chain_decorator'
         public: true
-        
+
     Flagception\Manager\FeatureManagerInterface: '@flagception.manager.feature_manager'
 
     flagception.expression_language:


### PR DESCRIPTION
```php
    /**
     * @Route("/blog/{page}", condition="service('flagception.manager.feature_manager').isActive('feature_123')")
     */
    public function listAction($page)
    {
        // ...
    }
```

For Symfony 6.1 users, this feels a bit cleaner than setting a value in the routing "defaults"  _feature key.  