### PR TITLE
Fix debug:config console-command

### DIFF
--- a/src/DependencyInjection/FlagceptionExtension.php
+++ b/src/DependencyInjection/FlagceptionExtension.php
@@ -68,6 +68,11 @@ class FlagceptionExtension extends Extension
         }
     }
 
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration($this->getConfigurators($container));
+    }
+
     /**
      * Get configurators
      *


### PR DESCRIPTION
The `console debug:config flagception` command currently throws the following error:

> In AbstractConfigCommand.php line 126:
>                                                                                             
>  The extension with alias "flagception" does not have its getConfiguration() method setup.  

This PR fixes this problem